### PR TITLE
Remove required input for entry time

### DIFF
--- a/app/asistencias.html
+++ b/app/asistencias.html
@@ -32,7 +32,7 @@
                 </div>
                 <div class="form-labels">
                     <label for="entryTime">Hora de entrada</label>
-                    <input type="time" id="entryTime" name="entryTime" required
+                    <input type="time" id="entryTime" name="entryTime"
                         placeholder="Ingresa la hora de entrada">
                 </div>
                 <div class="form-labels">


### PR DESCRIPTION
Eliminate the mandatory requirement for the entry time input field in the attendance form.